### PR TITLE
Fix mentorship redirection

### DIFF
--- a/content/mentoring/mentors.md
+++ b/content/mentoring/mentors.md
@@ -52,7 +52,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">C++</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -92,7 +92,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Procesos Químicos</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -133,7 +133,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Kubernetes</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=luisgagocasas&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -200,7 +200,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Auditoría de Sistemas</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=Aledonisgt&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -240,7 +240,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Privacidad</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=piratax007&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -278,7 +278,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Flutter</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=mateushvenancio&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>

--- a/content/mentoring/mentors.md
+++ b/content/mentoring/mentors.md
@@ -52,7 +52,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">C++</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new/choose">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -92,7 +92,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Procesos Químicos</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new/choose">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -133,7 +133,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Kubernetes</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new/choose">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -200,7 +200,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Auditoría de Sistemas</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new/choose">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -240,7 +240,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Privacidad</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new/choose">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>
@@ -278,7 +278,7 @@ singlecolumn = true
           <span class="badge bg-light text-dark">Flutter</span>
         </div>
         <div class="mt-3">
-          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new/choose">
+          <a href="https://github.com/OpenScienceLabs/request-forms/issues/new?assignees=EverVino%2C+xmnlab&labels=mentoring-request&template=es-mentoring-request.yaml&title=Solicitud+de+mentor%C3%ADa%3A+%3CINFORME+TU+NOMBRE+AQU%C3%8D%3E">
             <button class="btn bg-primary text-light">
               Solicitud de Mentoría
             </button>


### PR DESCRIPTION
Fix https://github.com/OpenScienceLabs/request-forms/issues/20 partially

The URL looks very hardcoded, but I've check it and I don't see any changes to do. One thing that could be done tho, is to change the issue Assignee to each mentor button. The way it is will check @xmnlab and @EverVino by default.