### PR TITLE
Past events added on events page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,7 @@ nav:
       - Partners: 'partnership/partners/index.md'
   - Events:
     - index: events/index.md
-    - "OpenVerse'24": events/openverse24/index.md
+    # - "OpenVerse'24": events/openverse24/index.md
   - Guidelines:
     - index: guidelines/index.md
     - Articles: guidelines/articles/index.md

--- a/pages/careers/internship/index.md
+++ b/pages/careers/internship/index.md
@@ -24,7 +24,7 @@ unique features:
   embracing diversity in knowledge and experience. Potential candidates should feel free to submit project ideas at any time as there are no internship cycles. 
 - **Flexible Commitment**: A minimum of 20 hours per week allows for impactful
   work while accommodating your schedule.
-- **End-of-Internship Presentations**: At the end of each every, individual   participants are
+- **End-of-Internship Presentations**: At the end of every internship, individual   participants are
   encouraged to share their journey and project outcomes, enhancing their public
   speaking and technical communication skills.
 - **Non-Monetary Rewards**: While the internship does not offer financial

--- a/pages/careers/internship/index.md
+++ b/pages/careers/internship/index.md
@@ -21,12 +21,10 @@ With a structure inspired by the Google Summer of Code, our program offers some
 unique features:
 
 - **Open Participation**: We welcome everyone from students to professionals,
-  embracing diversity in knowledge and experience.
+  embracing diversity in knowledge and experience. Potential candidates should feel free to submit project ideas at any time as there are no internship cycles. 
 - **Flexible Commitment**: A minimum of 20 hours per week allows for impactful
   work while accommodating your schedule.
-- **Biannual Cycles**: With two distinct cycles per year, there are ample
-  opportunities to get involved at a time that suits you best.
-- **End-of-Cycle Presentations**: At the end of each cycle, participants are
+- **End-of-Internship Presentations**: At the end of each every, individual   participants are
   encouraged to share their journey and project outcomes, enhancing their public
   speaking and technical communication skills.
 - **Non-Monetary Rewards**: While the internship does not offer financial

--- a/pages/events/index.md
+++ b/pages/events/index.md
@@ -5,15 +5,46 @@ authors: ["OSL Team"]
 template: events.html
 events:
   upcoming:
-    - name: "OpenVerse'24 - Stage 1"
+    - name: "OpenVerse - Stage 1"
       description: |
-        OpenVerse'24 is a beginner-friendly hackathon designed to welcome newcomers to
+        OpenVerse will be a beginner-friendly hackathon designed to welcome newcomers to
         the open-source development community. Our mission is to provide a supportive
         environment for learning and contributing to open-source projects, with a strong
         focus on education and practical experience.
       thumbnail: /images/events/openverse24.png
-      url: /events/openverse24
-      date_start: February 29th, 2024 (10:00 am IST)
-      date_end: March 1st, 2024 (10:00 am IST)
-  past: {}
+      date_start: 2025
+      date_end: 2025
+  
+  past_events:
+    - name: "OSL-PyCafe 3"
+      description: |
+        The OSL-PyCafe 3 event featured YouTube Live Sessions with David Ochoa presenting on "Use of Sympy in Engineering Education" and Fransico Palm presenting on "Intro to Scikit-risk".
+      thumbnail: /images/logos/logo.png
+      url: https://www.youtube.com/watch?v=SkaXPIzolPs
+      date_start: August 29th, 2024 
+      date_end: August 29th, 2024
+
+    - name: "Collaborative localization of documentation: Scikit-Learn and Matplotlib Cases"
+      description: |
+        Mariangela Petrizzo made an insightful presentation in this event, speaking about collaborative work, internationlization vs localization, why translate documentation, and more. 
+      thumbnail: /images/logos/logo.png
+      url: https://www.youtube.com/watch?v=hsrIDxiHkVk
+      date_start: September 23rd, 2022
+      date_end: September 23rd, 2022 
+
+    - name: "OSL-PyCafe 2"
+      description: |
+        The OSL-PyCafe 2 was lush with educative YouTube Live Sessions. Ivan Ogaswara made a presentation titled "Introduction to Semantic Releases". In the same event, Raniere Silva made a presentation on "Everything you need to know about GitLab CI in 10 minutes" and Pablo Navarro narrated the "Reconstruction of Iberian ceramics using generative networks".
+      thumbnail: /images/logos/logo.png  
+      url: https://www.youtube.com/watch?v=h4XeorBiV18 
+      date_start: August 25th, 2022
+      date_end: August 25th, 2022
+
+    - name: "OSL-PyCafe 1"
+      description: |
+       OSL-PyCafe maiden edition was nothing short of remarkable. The event featured three YouTube Live presentations from Rafael Villca, Alex de Siqueira, and Fransisco Palm who spoke on "How to Speed Up Your Python Code?", "An Overview of Scikit-image", and "Spreadsheets, Databases and Dataframes" respectively.
+      thumbnail: /images/logos/logo.png
+      urls: https://www.youtube.com/watch?v=lPsOB8dEiNI&t=134s
+      date_start: August 5th, 2022
+      date_end: August 5th, 2022
 ---

--- a/pages/guidelines/index.md
+++ b/pages/guidelines/index.md
@@ -36,19 +36,19 @@ In this section we can find our initial DEI declaration.
   <li><a href="/guidelines/dei/">Statement on Diversity, Equity and Inclusion</a></li>
 </ul>
 
-## DevOps
+<!-- ## DevOps
 
 In this section, we have the documentation about all our infrastructure (work in
 progress), and our goal is to have the necessary information for anyone who
-wants to help us in the DevOps tasks.
+wants to help us in the DevOps tasks. -->
 
-### Discord
+<!-- ### Discord
 
 <ul>
   <li><a href="/guidelines/devops/discord">Guideline for Discord</a></li>
-</ul>
+</ul> -->
 
-## Fund Raiser
+<!-- ## Fund Raiser
 
 In the section, we are gathering all the information and investigation results
 about grants, institutes, fiscal sponsors, etc that can help us to decide the
@@ -56,29 +56,23 @@ fund raising activities and help other communities as well.
 
 <ul>
   <li><a href="/guidelines/fund-raiser/">Fund Raiser Guideline</a></li>
-</ul>
+</ul> -->
 
 ## Mentoring
 
-In this section, there are documents about Open Science Labs Mentoring program.
-The mentoring could be running as a community mentoring, where someone from the
-community for the mentoring program and Open Science Labs tries to find one
-mentor inside our community, using discord, or using the social media, in order
-to reach someone outside.
-
-Another way that the mentoring can happen is inside the internship program.
+In this section, there is a document about Open Science Labs Mentoring program.
+Mentoring can happen within the community, such as through Discord or any of our social media channels. Another way that mentoring can happen is through the internship program. 
 
 <ul>
   <li><a href="/guidelines/mentoring">Mentoring Guideline</a></li>
-  <li><a href="/guidelines/coc-mentoring">Code of Conduct for Mentoring</a></li>
-</ul>
+</ul> 
 
-## Roadmap
+<!-- ## Roadmap
 
 If you are interested in the Open Science Labs next steps, please check our
-[Roadmap](/guidelines/roadmap/).
+[Roadmap](/guidelines/roadmap/). -->
 
-## Governance
+<!-- ## Governance
 
 For more information about our project governance, please check
-[governance document](/guidelines/governance/).
+[governance document](/guidelines/governance/). -->


### PR DESCRIPTION
All events now show directly on the events page. 

Past events section updated with four events. 
Minor edits made to OpenVerse event detail. 