### PR TITLE
Fixed inconsistent formatting in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ Ensure you have installed the pre-commit config locally:
 
 ```bash
 # with your conda env active, run:
-$ pre-commit install
+pre-commit install
 ```


### PR DESCRIPTION
### What does this PR do?
This PR updates the documentation to remove the `$` symbol in the `pre-commit install` command for consistency with other terminal commands in the setup instructions.

### Changes:
- Removed `$` from `pre-commit install` to match the formatting of other commands.
- Ensured uniformity in how terminal commands are presented in the documentation.

### Why this change?
- The `$` symbol is typically used to indicate a shell command in examples, but since other commands in the instructions don’t include it, removing it improves clarity and consistency.
- This helps avoid potential confusion for users copying commands directly.