### PR TITLE
Remove funding.json/index.md HTML docs; serve raw funding.json only

### DIFF
--- a/pages/funding.json
+++ b/pages/funding.json
@@ -1,4 +1,5 @@
-{ "version": "v1.0.0",
+{
+  "version": "v1.0.0",
   "entity": {
     "type": "organisation",
     "role": "owner",
@@ -18,7 +19,6 @@
       "description": "ASTx is a groundbreaking library designed to encapsulate language components in an agnostic and pythonic way. It provides a comprehensive set of classes and functionalities, allowing developers to articulate the core elements of any programming language.",
       "webpageUrl": {
         "url": "https://astx.arxlang.org"
-
       },
       "repositoryUrl": {
         "url": "https://github.com/arxlang/astx",
@@ -26,19 +26,17 @@
       }
     },
 
-      {
+    {
       "guid": "sugar",
       "name": "Sugar",
       "description": "Sugar is a tool that helps users organize their stack of containers and any additional scripts. ",
       "webpageUrl": {
         "url": "https://osl-incubator.github.io/sugar"
-
       },
       "repositoryUrl": {
         "url": "https://github.com/osl-incubator/sugar",
         "wellKnown": "https://github.com/opensciencelabs/opensciencelabs.github.io/tree/main/.well-known/funding-manifest-urls"
       }
-
     },
 
     {
@@ -47,13 +45,11 @@
       "description": "Makim is a YAML-based task automation tool offering structures for the definition for tasks and dependencies, with  support for conditionals.",
       "webpageUrl": {
         "url": "https://osl-incubator.github.io/makim"
-
       },
       "repositoryUrl": {
         "url": "https://github.com/osl-incubator/makim",
         "wellKnown": "https://github.com/opensciencelabs/opensciencelabs.github.io/tree/main/.well-known/funding-manifest-urls"
       }
-
     },
 
     {
@@ -62,13 +58,11 @@
       "description": "Scicookie is a template which creates projects from project templates and is based on Cookiecutter. It serves as an initial structure to simply project creation processes.",
       "webpageUrl": {
         "url": "https://osl-incubator.github.io/scicookie"
-
       },
       "repositoryUrl": {
         "url": "https://github.com/osl-incubator/scicookie",
         "wellKnown": "https://github.com/opensciencelabs/opensciencelabs.github.io/tree/main/.well-known/funding-manifest-urls"
       }
-
     },
 
     {
@@ -77,13 +71,11 @@
       "description": "Artbox is a tool that handles multimedia files processing, such as conversion from speech to text and vice versa.",
       "webpageUrl": {
         "url": "https://osl-incubator.github.io/artbox"
-
       },
       "repositoryUrl": {
         "url": "https://github.com/osl-incubator/artbox",
         "wellKnown": "https://github.com/opensciencelabs/opensciencelabs.github.io/tree/main/.well-known/funding-manifest-urls"
       }
-
     }
   ],
 

--- a/pages/funding.json
+++ b/pages/funding.json
@@ -1,13 +1,3 @@
----
-title: "funding.json"
-description: "Open Science Labs, sharing knowledge"
-date: "2019-02-28"
-authors: ["OSL Team"]
----
-
-## Here's the OSL funding.json manifest
-
-```
 { "version": "v1.0.0",
   "entity": {
     "type": "organisation",
@@ -143,4 +133,3 @@ authors: ["OSL Team"]
     ]
   }
 }
-```


### PR DESCRIPTION
## Add funding.json to be served directly as a raw file.
1. Removed the older pages/funding.json/index.md html rendering.
2. Added a raw funding.json file.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5b33b583-b3f5-41b9-b62e-85192b8df3cd" />

Result:
The raw json file can be viewed using https://opensciencelabs.org/funding.json route.