### PR TITLE
fix: Fix project page list

### DIFF
--- a/pages/projects/list/index.md
+++ b/pages/projects/list/index.md
@@ -166,7 +166,7 @@ projects:
       SciCookie is a template developed by Open Science Labs that creates
       projects from project templates.
 
-- name: SDX
+  - name: SDX
     type: affiliated
     maintainer_name: Ivan Ogasawara
     maintainer_email: ivan.ogasawara@gmail.com


### PR DESCRIPTION
# Summary

This PR fixes #237 the YAML syntax issue in
pages/projects/list/index.md, which caused MkDocs to throw multiple document parsing errors and break the Affiliated and Incubated Projects page layout.

# Changes Made:

- Corrected improper indentation for the SDX project entry in the YAML header (moved under the projects: list)
- Validated YAML structure to ensure a single document stream
- Verified that projects.html template now renders all project cards correctly