### PR TITLE
fix: use full git history in build job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,7 +35,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
The build job was doing a shallow clone, which meant `git-revision-date-localized` couldn't read last-modified dates for most pages. With `--strict` enabled, those warnings break the build and the site never deploys.

Added `fetch-depth: 0` to fix it, and bumped `actions/checkout` to v4 while I was at it.