### PR TITLE
dx: add “Edit this page on GitHub” links #265

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,10 @@
 site_name: Open Science Labs
 site_url: https://opensciencelabs.org
 
+# Repository / edit links (used to build "Edit this page on GitHub" URLs)
+repo_url: https://github.com/OpenScienceLabs/opensciencelabs.github.io
+edit_uri: edit/main/
+
 docs_dir: pages
 site_dir: build
 

--- a/theme/base.html
+++ b/theme/base.html
@@ -373,6 +373,16 @@
                 {% block content_inner %}
                   {{ page.content }}
                 {% endblock content_inner %}
+
+                {# Inline "Edit this page on GitHub" helper. Uses MkDocs page.edit_url. #}
+                {% if page.edit_url %}
+                <div class="mt-4 edit-on-github">
+                  <a href="{{ page.edit_url }}" target="_blank" rel="noopener"
+                     class="edit-link small text-secondary">
+                    Found an issue? <span class="edit-link-text">Edit this page on GitHub ↗</span>
+                  </a>
+                </div>
+                {% endif %}
               </div>
             </div>
           </section>

--- a/theme/css/content.css
+++ b/theme/css/content.css
@@ -42,3 +42,14 @@ blockquote{
   display: grid; place-items: center;
 }
 .to_top .icon { width: 24px; height: 24px; }
+
+/* "Edit this page on GitHub" helper */
+.edit-on-github {
+  margin-top: 1.25rem;
+}
+.edit-on-github .edit-link {
+  text-decoration: none;
+}
+.edit-on-github .edit-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
This PR wires up MkDocs’ edit URLs and shows a small “Edit this page on GitHub” link on docs and blog posts.

What changed 
issue: #265

- Set `repo_url` and `edit_uri` in `mkdocs.yml` so MkDocs exposes `page.edit_url`.
- In `theme/base.html`, render a short “Found an issue? Edit this page on GitHub ↗” helper below the main content when `page.edit_url` is available.
- Added a tiny bit of CSS in `theme/css/content.css` so the link looks consistent with the rest of the theme.

Notes

- The helper lives in `base.html`, so it applies both to regular docs and to blog posts that use `blog-post.html` / other inherited layouts.
- The link always points to this repo (`OpenScienceLabs/opensciencelabs.github.io`) on the `main` branch.